### PR TITLE
Make setting amf properties fallible

### DIFF
--- a/source/encoder.cpp
+++ b/source/encoder.cpp
@@ -184,26 +184,26 @@ void Encoder::apply_settings(obs_data &data, obs_encoder &obs_encoder) {
 
   configure_encoder_with_obs_user_settings(*amf_encoder, data);
   // important for rate control
-  set_property_(*amf_encoder, details.frame_rate_property,
-                AMFConstructRate(voi.fps_num, voi.fps_den));
+  set_property_fallible(*amf_encoder, details.frame_rate_property,
+                        AMFConstructRate(voi.fps_num, voi.fps_den));
 
   const auto color = obs_color_space_to_amf(voi.colorspace, voi.range);
   set_color_range(*amf_encoder, color.range);
-  set_property_(*amf_encoder, details.input_color_properties.profile,
-                static_cast<int64_t>(color.profile));
-  set_property_(*amf_encoder,
-                details.input_color_properties.transfer_characteristic,
-                static_cast<int64_t>(color.transfer_characteristic));
-  set_property_(*amf_encoder, details.input_color_properties.primaries,
-                static_cast<int64_t>(color.primaries));
+  set_property_fallible(*amf_encoder, details.input_color_properties.profile,
+                        static_cast<int64_t>(color.profile));
+  set_property_fallible(*amf_encoder,
+                        details.input_color_properties.transfer_characteristic,
+                        static_cast<int64_t>(color.transfer_characteristic));
+  set_property_fallible(*amf_encoder, details.input_color_properties.primaries,
+                        static_cast<int64_t>(color.primaries));
   // Unsure whether needs to be set on output.
-  set_property_(*amf_encoder, details.output_color_properties.profile,
-                static_cast<int64_t>(color.profile));
-  set_property_(*amf_encoder,
-                details.output_color_properties.transfer_characteristic,
-                static_cast<int64_t>(color.transfer_characteristic));
-  set_property_(*amf_encoder, details.output_color_properties.primaries,
-                static_cast<int64_t>(color.primaries));
+  set_property_fallible(*amf_encoder, details.output_color_properties.profile,
+                        static_cast<int64_t>(color.profile));
+  set_property_fallible(*amf_encoder,
+                        details.output_color_properties.transfer_characteristic,
+                        static_cast<int64_t>(color.transfer_characteristic));
+  set_property_fallible(*amf_encoder, details.output_color_properties.primaries,
+                        static_cast<int64_t>(color.primaries));
 }
 
 void Encoder::set_extra_data() {
@@ -276,7 +276,8 @@ void Encoder::send_frame_to_encoder(SurfaceType surface_type) {
     log(LOG_DEBUG, "send_frame_to_encoder: need more input");
     break;
   case AMF_INPUT_FULL:
-    // This can happen on overloaded systems. We can't do anything except drop the frame.
+    // This can happen on overloaded systems. We can't do anything except drop
+    // the frame.
     log(LOG_DEBUG, "send_frame_to_encoder: input full");
     log(LOG_WARNING, "dropping frame because encoder is overloaded");
     break;

--- a/source/encoder_avc.cpp
+++ b/source/encoder_avc.cpp
@@ -11,8 +11,8 @@ void EncoderAvc::configure_encoder_with_obs_user_settings(
   // The usage determines default values for other properties. We manually set
   // almost all properties so it is not necessary for the user to pick the
   // usage.
-  set_property_(encoder, AMF_VIDEO_ENCODER_USAGE,
-                AMF_VIDEO_ENCODER_USAGE_TRANSCONDING);
+  set_property_fallible(encoder, AMF_VIDEO_ENCODER_USAGE,
+                        AMF_VIDEO_ENCODER_USAGE_TRANSCONDING);
   for (const auto &setting : settings) {
     setting->amf_property(obs_data, encoder);
   }
@@ -20,8 +20,8 @@ void EncoderAvc::configure_encoder_with_obs_user_settings(
 
 void EncoderAvc::set_color_range(amf::AMFPropertyStorage &encoder,
                                  ColorRange color_range) {
-  set_property(encoder, AMF_VIDEO_ENCODER_FULL_RANGE_COLOR,
-               color_range == ColorRange::Full);
+  set_property_fallible(encoder, AMF_VIDEO_ENCODER_FULL_RANGE_COLOR,
+                        color_range == ColorRange::Full);
 }
 
 PacketInfo EncoderAvc::get_packet_info(amf::AMFPropertyStorage &output) {
@@ -128,8 +128,8 @@ const S settings_[] = {
                      26}},
     S{new IntSetting{"qp b", "CQP: B Frame QP", AMF_VIDEO_ENCODER_QP_B, 0, 51,
                      26}},
-    S{new IntSetting{"qvbr quality level", "QVBR Quality Level", AMF_VIDEO_ENCODER_QVBR_QUALITY_LEVEL,
-                     1, 51, 23}},
+    S{new IntSetting{"qvbr quality level", "QVBR Quality Level",
+                     AMF_VIDEO_ENCODER_QVBR_QUALITY_LEVEL, 1, 51, 23}},
     S{new IntSetting{"vbv buffer size", "VBV Buffer Size",
                      AMF_VIDEO_ENCODER_VBV_BUFFER_SIZE, 1,
                      std::numeric_limits<int>::max(), 20000000}},

--- a/source/encoder_hevc.cpp
+++ b/source/encoder_hevc.cpp
@@ -8,8 +8,8 @@
 
 void EncoderHevc::configure_encoder_with_obs_user_settings(
     amf::AMFComponent &encoder, obs_data &obs_data) {
-  set_property_(encoder, AMF_VIDEO_ENCODER_HEVC_USAGE,
-                AMF_VIDEO_ENCODER_HEVC_USAGE_TRANSCONDING);
+  set_property_fallible(encoder, AMF_VIDEO_ENCODER_HEVC_USAGE,
+                        AMF_VIDEO_ENCODER_HEVC_USAGE_TRANSCONDING);
   for (const auto &setting : settings) {
     setting->amf_property(obs_data, encoder);
   }
@@ -24,7 +24,7 @@ void EncoderHevc::set_color_range(amf::AMFPropertyStorage &encoder,
   case ColorRange::Full:
     value = AMF_VIDEO_ENCODER_HEVC_NOMINAL_RANGE_FULL;
   }
-  set_property(encoder, AMF_VIDEO_ENCODER_HEVC_NOMINAL_RANGE, value);
+  set_property_fallible(encoder, AMF_VIDEO_ENCODER_HEVC_NOMINAL_RANGE, value);
 }
 
 PacketInfo EncoderHevc::get_packet_info(amf::AMFPropertyStorage &output) {
@@ -56,8 +56,7 @@ EncoderHevc::EncoderHevc()
                .transfer_characteristic =
                    AMF_VIDEO_ENCODER_HEVC_OUTPUT_TRANSFER_CHARACTERISTIC,
                .primaries = AMF_VIDEO_ENCODER_HEVC_OUTPUT_COLOR_PRIMARIES},
-      }) {
-}
+      }) {}
 
 namespace {
 

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -20,7 +20,7 @@ void BoolSetting::obs_default(obs_data &data) const noexcept {
 void BoolSetting::amf_property(obs_data &data,
                                amf::AMFComponent &encoder) const {
   const auto value{obs_data_get_bool(&data, name)};
-  set_property_(encoder, amf_name, value);
+  set_property_fallible(encoder, amf_name, value);
 }
 
 IntSetting::IntSetting(not_null<czstring> name, not_null<czstring> description,
@@ -49,7 +49,7 @@ void IntSetting::obs_default(obs_data &data) const noexcept {
 void IntSetting::amf_property(obs_data &data,
                               amf::AMFComponent &encoder) const {
   const auto value{gsl::narrow<int>(obs_data_get_int(&data, name))};
-  set_property_(encoder, amf_name, static_cast<int64_t>(value));
+  set_property_fallible(encoder, amf_name, static_cast<int64_t>(value));
 }
 
 EnumSetting::EnumSetting(
@@ -79,5 +79,5 @@ void EnumSetting::obs_default(obs_data &data) const noexcept {
 void EnumSetting::amf_property(obs_data &data,
                                amf::AMFComponent &encoder) const {
   const auto value{gsl::narrow<int>(obs_data_get_int(&data, name))};
-  set_property_(encoder, amf_name, static_cast<int64_t>(value));
+  set_property_fallible(encoder, amf_name, static_cast<int64_t>(value));
 }

--- a/source/util.h
+++ b/source/util.h
@@ -42,13 +42,17 @@ void set_property(amf::AMFPropertyStorage &storage, not_null<cwzstring> name,
   }
 }
 
-// like above but with logging
+// like above but with logging and without throwing
 template <AmfVariant T>
-void set_property_(amf::AMFPropertyStorage &storage, not_null<cwzstring> name,
-                   const T &value) {
-  log(LOG_INFO,
-      fmt::format("SetProperty {} {}", wstring_to_string(name), value));
-  set_property(storage, name, value);
+void set_property_fallible(amf::AMFPropertyStorage &storage,
+                           not_null<cwzstring> name, const T &value) noexcept {
+  if (storage.SetProperty(name, value) == AMF_OK) {
+    log(LOG_INFO,
+        fmt::format("SetProperty OK {} {}", wstring_to_string(name), value));
+  } else {
+    log(LOG_ERROR,
+        fmt::format("SetProperty ERR {} {}", wstring_to_string(name), value));
+  }
 }
 
 // get property or throw


### PR DESCRIPTION
For some users on older GPUs setting properties in a way that is correct
according to the AMF documentation fails. To workaround this we make
almost all properties fallible, logging the error. Hopefully this allows
those users to still use the plugin.

Related to:
- https://github.com/e00E/obs-amf/issues/5
- https://github.com/e00E/obs-amf/issues/27
- https://github.com/e00E/obs-amf/issues/30